### PR TITLE
Added an option to set the initial ticks or not

### DIFF
--- a/Servo.cpp
+++ b/Servo.cpp
@@ -382,15 +382,22 @@ Servo::Servo()
 
 uint8_t Servo::attach(int pin)
 {
-	return attach(pin, MIN_PULSE_WIDTH, MAX_PULSE_WIDTH);
+	return attach(pin, MIN_PULSE_WIDTH, MAX_PULSE_WIDTH, true);
 }
 
-uint8_t Servo::attach(int pin, int minimum, int maximum)
+uint8_t Servo::attach(int pin, bool set)
+{
+  return attach(pin, MIN_PULSE_WIDTH, MAX_PULSE_WIDTH, set);
+}
+
+uint8_t Servo::attach(int pin, int minimum, int maximum, bool set)
 {
 	if (servoIndex < MAX_SERVOS) {
 		pinMode(pin, OUTPUT);
 		servo_pin[servoIndex] = pin;
-		servo_ticks[servoIndex] = usToTicks(DEFAULT_PULSE_WIDTH);
+    if(set) {
+		  servo_ticks[servoIndex] = usToTicks(DEFAULT_PULSE_WIDTH);
+    }
 		servo_active_mask |= (1<<servoIndex);
 		min_ticks = usToTicks(minimum);
 		max_ticks = usToTicks(maximum);

--- a/Servo.h
+++ b/Servo.h
@@ -111,6 +111,12 @@ public:
   Servo();
   uint8_t attach(int pin);           // attach the given pin to the next free channel, sets pinMode, returns channel number or 0 if failure
   uint8_t attach(int pin, int min, int max); // as above but also sets min and max values for writes. 
+
+  #if defined(__arm__)
+  uint8_t attach(int pin, bool set);
+  uint8_t attach(int pin, int minimum, int maximum, bool set);
+  #endif
+
   void detach();
   void write(int value);             // if value is < 200 its treated as an angle, otherwise as pulse width in microseconds 
   void writeMicroseconds(int value); // Write pulse width in microseconds 


### PR DESCRIPTION
I found the servos jump to a position when calling _attach_. This is problematic for applications where servos are used in robots, with heavier and long lever arms on the servos. The solution is to include a boolean to determine if we want to set the initial ticks or not. True by default, as this was the original functionality.

Now, by calling _attach(pin, false)_, the servo will not jump to an initial position. It can still be set to a position afterwards successfully.

Tested on Bowie robot, using a Teensy 3.2.